### PR TITLE
allow reading from node env

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,4 +164,12 @@ export default {
 }
 ```
 
+#### Changing CORS Proxy
+
+To change the CORS proxy used by the adapters in local development, use the env variable `CORS_PROXY_URL`.
+
+```sh
+$ CORS_PROXY_URL="https://..." deno run ...
+```
+
 The function returns a record of `label`: `timestamp` which is in [UNIX time format](https://en.wikipedia.org/wiki/Unix_time). The labels are the same labels used in the adapter, if no labels are used by your other functions then use the label `Points`, which indicates that the points program has completely been deprecated.

--- a/utils/cors.ts
+++ b/utils/cors.ts
@@ -1,10 +1,14 @@
+import process from "node:process";
+
 const maybeReadEnv = (name: string, fallback: string) =>
   typeof Deno !== "undefined" && Deno.env.has(name)
     ? Deno.env.get(name)
     : typeof import.meta.env !== "undefined" &&
         Object.hasOwn(import.meta.env, "VITE_" + name)
       ? import.meta.env["VITE_" + name]
-      : fallback;
+      : typeof process !== "undefined" && process.env && process.env[name]
+        ? process.env[name]
+        : fallback;
 
 const CORS_PROXY_URL = maybeReadEnv(
   "CORS_PROXY_URL",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with instructions on how to change the CORS proxy by setting an environment variable during local development.

- **New Features**
  - Improved environment variable support to allow overriding the CORS proxy in Node.js environments, in addition to existing support for Deno and Vite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->