### PR TITLE
Fix multiple adapters + deprecated adapters

### DIFF
--- a/adapters/afx.ts
+++ b/adapters/afx.ts
@@ -1,99 +1,11 @@
-import { getAddress } from "viem";
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
-
-const API_URL = await maybeWrapCORSProxy(
-  "https://api10.afx.xyz/info/points/user?userAddr={address}",
-);
-
-type UserPoints = {
-  userAddr: string;
-  totalPoints: number | string;
-  tradingPoints: number | string;
-  lpPoints: number | string;
-  teamPoints: number | string;
-  bonusPoints: number | string;
-  cumulativeVolume: number | string;
-  cumulativeRealizedPnl: number | string;
-  lastSettledWeek: string | null;
-  currentRank: number | null;
-};
-
-type API_RESPONSE = {
-  code: number;
-  message?: string;
-  data?: UserPoints;
-};
-
-const toNumber = (value: number | string | null | undefined): number =>
-  Number(value ?? 0) || 0;
-
-const getPoints = (data: API_RESPONSE): UserPoints => {
-  if (!data.data) {
-    return {
-      userAddr: "",
-      totalPoints: 0,
-      tradingPoints: 0,
-      lpPoints: 0,
-      teamPoints: 0,
-      bonusPoints: 0,
-      cumulativeVolume: 0,
-      cumulativeRealizedPnl: 0,
-      lastSettledWeek: null,
-      currentRank: null,
-    };
-  }
-
-  return data.data;
-};
 
 export default {
-  fetch: async (address: string): Promise<API_RESPONSE> => {
-    const normalizedAddress = getAddress(address).toLowerCase();
-    const response = await fetch(
-      API_URL.replace("{address}", normalizedAddress),
-      {
-        headers: {
-          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
-        },
-      },
-    );
-
-    if (!response.ok) {
-      throw new Error(
-        `AFX points request failed with status ${response.status}`,
-      );
-    }
-
-    const data = await response.json() as API_RESPONSE;
-    if (data.code !== 0) {
-      throw new Error(
-        data.message ?? `AFX points request failed: ${data.code}`,
-      );
-    }
-
-    return data;
-  },
-  data: (data: API_RESPONSE) => {
-    const points = getPoints(data);
-
-    return {
-      Points: {
-        "Total Points": toNumber(points.totalPoints),
-        "Trading Points": toNumber(points.tradingPoints),
-        "LP Points": toNumber(points.lpPoints),
-        "Team Points": toNumber(points.teamPoints),
-        "Bonus Points": toNumber(points.bonusPoints),
-        "Cumulative Volume": toNumber(points.cumulativeVolume),
-        "Cumulative Realized PnL": toNumber(points.cumulativeRealizedPnl),
-        "Last Settled Week": points.lastSettledWeek ?? "N/A",
-        Rank: toNumber(points.currentRank),
-      },
-    };
-  },
-  total: (data: API_RESPONSE) => ({
-    Points: toNumber(getPoints(data).totalPoints),
+  fetch: async () => await Promise.resolve({}),
+  data: () => ({}),
+  total: () => ({ Points: 0 }),
+  deprecated: () => ({
+    Points: 1788134400, // August 31st 2026 00:00 UTC
   }),
-  rank: (data: API_RESPONSE) => toNumber(getPoints(data).currentRank),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/aroundtw.ts
+++ b/adapters/aroundtw.ts
@@ -1,78 +1,11 @@
-import { getAddress } from "viem";
-import { titleCase } from "text-case";
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://basearoundtheworld.vercel.app/api/player?address={address}&_t={timestamp}",
-);
-
-type API_RESPONSE = {
-  player: {
-    name: string;
-    totalScore: number;
-    levelsCompleted: number;
-    bestLevel: number;
-    referralRewarded: boolean;
-  };
-  progress: Array<Record<string, string | number>>;
-};
 export default {
-  fetch: async (address) => {
-    const timestamp = Date.now().toString();
-    const res = await fetch(
-      API_URL.replace("{address}", getAddress(address)).replace(
-        "{timestamp}",
-        timestamp,
-      ),
-      {
-        headers: {
-          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
-        },
-      },
-    );
-    const data: API_RESPONSE = await res.json();
-    if (!data.player) {
-      return {
-        player: {
-          name: "Unknown user",
-          totalScore: 0,
-          levelsCompleted: 0,
-          bestLevel: 0,
-        },
-        progress: [],
-      };
-    }
-    return data;
-  },
-  data: (data: API_RESPONSE) => {
-    const progressData: Record<string, string | number> = {};
-    const { progress } = data;
-
-    for (let index = 0; index < progress.length; index++) {
-      const obj = progress[index];
-      const levelPrefix = `Level ${index + 1} `;
-
-      for (const rawKey in obj) {
-        const titledKey = titleCase(rawKey);
-        const rawValue = obj[rawKey];
-        const outputKey = `${levelPrefix}${titledKey}`;
-
-        if (titledKey === "Completed At") {
-          progressData[outputKey] = new Date(rawValue).toLocaleString();
-        } else {
-          progressData[outputKey] = rawValue;
-        }
-      }
-    }
-
-    return {
-      Name: data.player.name,
-      "Levels Completed": data.player.levelsCompleted,
-      "Best Level": data.player.bestLevel,
-      ...progressData,
-    };
-  },
-  total: (data: API_RESPONSE) => data.player.totalScore,
+  fetch: async () => await Promise.resolve({}),
+  data: () => ({}),
+  total: () => 0,
+  deprecated: () => ({
+    Points: 1775001600, // April 1st 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/astherus.ts
+++ b/adapters/astherus.ts
@@ -1,10 +1,12 @@
 import type { AdapterExport } from "../utils/adapter.ts";
 
-// API requires signing in
 export default {
   fetch: async () => ({}),
   data: () => ({}),
   total: () => 0,
   claimable: () => false,
+  deprecated: () => ({
+    Points: 1788134400, // August 31st 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/avalon.ts
+++ b/adapters/avalon.ts
@@ -4,5 +4,8 @@ export default {
   fetch: async () => await Promise.resolve({}),
   data: () => ({}),
   total: () => 0,
+  deprecated: () => ({
+    Points: 1788134400, // August 31st 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/avant.ts
+++ b/adapters/avant.ts
@@ -1,10 +1,7 @@
 import { getAddress } from "viem";
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://app.avantprotocol.com/api/rewards/merkl/{address}"
-);
+const API_URL = "https://app.avantprotocol.com/api/rewards/merkl/{address}";
 
 type CampaignBreakdown = {
   campaignId?: string;

--- a/adapters/bedrock.ts
+++ b/adapters/bedrock.ts
@@ -48,7 +48,8 @@ const getTotalDiamonds = (data: API_RESPONSE): number =>
 const postBedrock = async <T>(
   url: string,
   address: string,
-): Promise<T | undefined> => {
+  requestName: string,
+): Promise<T> => {
   const res = await fetch(url, {
     method: "POST",
     body: JSON.stringify({ address: address.toLowerCase() }),
@@ -59,11 +60,21 @@ const postBedrock = async <T>(
     },
   });
 
-  if (!res.ok || !res.headers.get("content-type")?.includes("json")) {
-    return undefined;
+  if (!res.ok) {
+    throw new Error(
+      `Bedrock ${requestName} request failed with status ${res.status}`,
+    );
   }
 
-  return await res.json() as T;
+  if (!res.headers.get("content-type")?.includes("json")) {
+    throw new Error(`Bedrock ${requestName} request returned non-JSON content`);
+  }
+
+  try {
+    return await res.json() as T;
+  } catch {
+    throw new Error(`Bedrock ${requestName} request returned invalid JSON`);
+  }
 };
 
 export default {
@@ -72,16 +83,35 @@ export default {
       postBedrock<{ data?: { diamonds?: string | number } }>(
         EARNED_URL,
         address,
+        "earned Diamonds",
       ),
-      postBedrock<{ data?: Quest[] }>(QUESTS_URL, address),
+      postBedrock<{ data?: Quest[] }>(QUESTS_URL, address, "quests"),
     ]);
+
+    const earnedDiamonds = earnedResponse.data?.diamonds;
+    if (
+      typeof earnedDiamonds !== "string" &&
+      typeof earnedDiamonds !== "number"
+    ) {
+      throw new Error(
+        "Bedrock earned Diamonds request returned malformed data",
+      );
+    }
+    const earnedDiamondsNumber = Number(earnedDiamonds);
+    if (!Number.isFinite(earnedDiamondsNumber)) {
+      throw new Error(
+        "Bedrock earned Diamonds request returned malformed data",
+      );
+    }
+
+    if (!Array.isArray(questsResponse.data)) {
+      throw new Error("Bedrock quests request returned malformed data");
+    }
 
     return {
       ...emptyResponse(),
-      earnedDiamonds: earnedResponse?.data?.diamonds === undefined
-        ? undefined
-        : toNumber(earnedResponse.data.diamonds),
-      quests: questsResponse?.data ?? [],
+      earnedDiamonds: earnedDiamondsNumber,
+      quests: questsResponse.data,
     };
   },
   data: (data: API_RESPONSE) => ({

--- a/adapters/cap.ts
+++ b/adapters/cap.ts
@@ -1,27 +1,11 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
-
-const API_URL = await maybeWrapCORSProxy(
-  "https://api.cap.app/v1/caps/account/{address}"
-);
 
 export default {
-  fetch: async (address: string) => {
-    const res = await fetch(API_URL.replace("{address}", address), {
-      headers: {
-        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
-      },
-    });
-    return await res.json();
-  },
-  data: (data: { rank: number; caps: string }) => {
-    if (!data) return {};
-    return { Caps: data.caps, rank: data.rank };
-  },
-  total: (data: { caps: string }) => {
-    const points = data ? Number(data.caps) : 0;
-    return { Caps: points };
-  },
-  rank: (data: { rank: number }) => data.rank,
+  fetch: async () => await Promise.resolve({}),
+  data: () => ({}),
+  total: () => ({ Caps: 0 }),
+  deprecated: () => ({
+    Caps: 1784764800, // July 23rd 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/debridge.ts
+++ b/adapters/debridge.ts
@@ -1,9 +1,7 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://points-api-td.debridge.finance/api/Points/{address}/summary"
-);
+const API_URL =
+  "https://points-api-td.debridge.finance/api/Points/{address}/summary";
 
 const headers = {
   "User-Agent": "Checkpoint API (https://checkpoint.exchange)",

--- a/adapters/dolomite.ts
+++ b/adapters/dolomite.ts
@@ -2,11 +2,7 @@ import type { AdapterExport } from "../utils/adapter.ts";
 
 import { checksumAddress } from "viem";
 
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
-
-const AIRDROP_URL = await maybeWrapCORSProxy(
-  "https://api.dolomite.io/airdrop/regular/{address}"
-);
+const AIRDROP_URL = "https://api.dolomite.io/airdrop/regular/{address}";
 
 export default {
   fetch: async (address: string) => {

--- a/adapters/doma.ts
+++ b/adapters/doma.ts
@@ -1,9 +1,8 @@
 import { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 import { getAddress } from "viem";
 import { convertKeysToStartCase } from "../utils/object.ts";
 
-const API_URL = await maybeWrapCORSProxy("https://api.doma.xyz/graphql");
+const API_URL = "https://api.doma.xyz/graphql";
 
 export default {
   fetch: async (address: string) => {

--- a/adapters/ethena.ts
+++ b/adapters/ethena.ts
@@ -6,11 +6,9 @@ import {
   convertKeysToStartCase,
   convertValuesToNormal,
 } from "../utils/object.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://app.ethena.fi/api/referral/get-referree?address={address}"
-);
+const API_URL =
+  "https://app.ethena.fi/api/referral/get-referree?address={address}";
 
 // { queryWallet: [{ accumulatedTotalShardsEarned: 11.55 }] };
 export default {

--- a/adapters/fusion.ts
+++ b/adapters/fusion.ts
@@ -1,5 +1,4 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
 import {
   concatBytes,
@@ -12,7 +11,7 @@ import {
   toHex,
 } from "viem";
 
-const MERKL_API_URL = await maybeWrapCORSProxy("https://api.merkl.xyz/v4");
+const MERKL_API_URL = "https://api.merkl.xyz/v4";
 const EVENTS_API_URL = "https://ipor.dev";
 
 const GNOSIS_CHAIN_ID = 100;

--- a/adapters/gravityfinance.ts
+++ b/adapters/gravityfinance.ts
@@ -4,5 +4,8 @@ export default {
   fetch: async () => ({}),
   data: () => ({}),
   total: () => 0,
+  deprecated: () => ({
+    Points: 1788134400, // August 31st 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/hotstuff.ts
+++ b/adapters/hotstuff.ts
@@ -1,8 +1,7 @@
 import { getAddress } from "viem";
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy("https://api.hotstuff.trade/info");
+const API_URL = "https://api.hotstuff.trade/info";
 
 const headers = {
   "Content-Type": "application/json",

--- a/adapters/hyperflow.ts
+++ b/adapters/hyperflow.ts
@@ -3,7 +3,6 @@ import type { AdapterExport } from "../utils/adapter.ts";
 import { getAddress } from "viem";
 
 import { convertValuesToNormal } from "../utils/object.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
 // Working wallet: 0x5Db201AE15f9702f0a0Ff9F00b8c1c18355373d0
 
@@ -51,9 +50,8 @@ interface UserData {
   };
 }
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://api.hyperflow.fun/v1/point/leaderboard?from=1751367600&user={address}"
-);
+const API_URL =
+  "https://api.hyperflow.fun/v1/point/leaderboard?from=1751367600&user={address}";
 
 export default {
   fetch: async (address: string): Promise<UserData> => {

--- a/adapters/hypersurface.ts
+++ b/adapters/hypersurface.ts
@@ -1,10 +1,6 @@
 import type { AdapterExport } from "../utils/adapter.ts";
 
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
-
-const API_URL = await maybeWrapCORSProxy(
-  "https://points-api.hypersurface.io/points/{address}/state/"
-);
+const API_URL = "https://points-api.hypersurface.io/points/{address}/state/";
 
 type API_RESPONSE = {
   rank: {

--- a/adapters/hypurr.ts
+++ b/adapters/hypurr.ts
@@ -1,66 +1,11 @@
-import { getAddress } from "viem";
-import { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
-import { convertKeysToStartCase } from "../utils/object.ts";
-
-//"address": "0x243002fdc173a66a07ad9dee3a1466509b4203c4",
-
-type ApiResponse = {
-  page: number;
-  page_size: number;
-  results: {
-    address: string;
-    total_amount: number;
-    affiliate_code: string | null;
-    rank: number;
-    total_attributions: number;
-    tiers: Record<string, string>;
-  }[];
-  total_results: number;
-  calculated_at: string;
-};
-const API_URL = await maybeWrapCORSProxy(
-  "https://api.fuul.xyz/api/v1/payouts/leaderboard/points?user_identifier={address}&user_identifier_type=evm_address&fields=tier"
-);
+import type { AdapterExport } from "../utils/adapter.ts";
 
 export default {
-  fetch: async (address: string) => {
-    const res = await fetch(API_URL.replace("{address}", getAddress(address)), {
-      headers: {
-        Authorization:
-          "Bearer dd0f4f26be36808799f3d1ac5c87c850b58e8f03b964878f9680825132c29c06",
-        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
-      },
-    });
-    return await res.json();
-  },
-  data: (data: ApiResponse) => {
-    if (!data || !data.results || data.results.length === 0) return {};
-
-    const { tiers, ...rest } = data.results[0];
-
-    const flattened = {
-      ...(rest &&
-        Object.fromEntries(
-          Object.entries(rest).filter(
-            ([k, v]) => v !== null && v !== undefined && k !== "address"
-          )
-        )),
-      ...(tiers &&
-        Object.fromEntries(
-          Object.entries(tiers).map(([k, v]) => [`Tiers: ${k}`, v])
-        )),
-    };
-
-    return convertKeysToStartCase(flattened);
-  },
-  total: (data: ApiResponse) => {
-    if (!data || !data.results || data.results.length === 0) return 0;
-    return data.results[0].total_amount;
-  },
-  rank: (data: ApiResponse) => {
-    if (!data || !data.results || data.results.length === 0) return 0;
-    return data.results[0].rank;
-  },
+  fetch: async () => await Promise.resolve({}),
+  data: () => ({}),
+  total: () => 0,
+  deprecated: () => ({
+    Points: 1778889600, // May 16th 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/lombard.ts
+++ b/adapters/lombard.ts
@@ -1,42 +1,14 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
-import { isEmpty } from "lodash-es";
-import { convertKeysToStartCase } from "../utils/object.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://mainnet.prod.lombard.finance/api/v1/referral-system/season-3/points/{address}"
-);
-
-type API_RESPONSE = {
-  protocol_points_map: Record<string, number>;
-};
-
+// Season 3 ended on July 23rd, 2026. Season 4 activity is being tracked, but
+// Lombard has not published its incentives details or a supported points API.
 export default {
-  fetch: async (address: string) => {
-    const response = await fetch(API_URL.replace("{address}", address), {
-      headers: {
-        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
-      },
-    });
-    const data = await response.json();
-
-    // API returns an empty object when address doesn't exist
-    if (!data || isEmpty(data)) {
-      return {
-        protocol_points_map: {},
-      };
-    }
-    return data;
-  },
-  data: (data: API_RESPONSE) => ({
-    Lux: { ...convertKeysToStartCase(data.protocol_points_map) },
-  }),
-  total: (data: API_RESPONSE) => ({
-    Lux: Object.values(data.protocol_points_map).reduce(
-      (sum, points) => sum + points,
-      0
-    ),
-  }),
+  fetch: async () => await Promise.resolve({}),
+  data: () => ({}),
+  total: () => ({ Lux: 0 }),
   claimable: () => true,
+  deprecated: () => ({
+    Lux: 1784764800, // July 23rd 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/mainstreet.ts
+++ b/adapters/mainstreet.ts
@@ -1,10 +1,8 @@
 import { getAddress } from "viem";
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://api.mainstreet.finance/points/my-data?wallet={address}&season=3"
-);
+const API_URL =
+  "https://api.mainstreet.finance/points/my-data?wallet={address}&season=3";
 
 type API_RESPONSE = {
   success?: boolean;

--- a/adapters/makina.ts
+++ b/adapters/makina.ts
@@ -5,7 +5,7 @@ import { maybeWrapCORSProxy } from "../utils/cors.ts";
 const SEASON_0_API_URL = await maybeWrapCORSProxy(
   "https://makina.finance/api/points/{address}",
 );
-const MERKL_API_URL = await maybeWrapCORSProxy("https://api.merkl.xyz/v4");
+const MERKL_API_URL = "https://api.merkl.xyz/v4";
 
 const INK_CHAIN_ID = 57073;
 const MAKINA_POINTS_ADDRESS = "0x3419966bC74fa8f951108d15b053bEd233974d3D";

--- a/adapters/mellow.ts
+++ b/adapters/mellow.ts
@@ -1,10 +1,7 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 import { convertKeysToStartCase } from "../utils/object.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://points.mellow.finance/v1/users/{address}"
-);
+const API_URL = "https://points.mellow.finance/v1/users/{address}";
 
 type DATA_TYPE = {
   chain_id: number;

--- a/adapters/methprotocol.ts
+++ b/adapters/methprotocol.ts
@@ -1,54 +1,97 @@
 import type { AdapterExport } from "../utils/adapter.ts";
 
-const API_URL = "https://cmeth-api-v2.mantle.xyz/points/{address}";
+const API_URL = "https://cmeth.api.methprotocol.xyz/points/s3/{address}";
 
-/**
-{
-  message: "ok",
-  code: 0,
-  data: {
-    walletAddress: "0x7044c9382e76b6a32a817a5156a36b9fbcefb61e",
-    totalPoints: 809.8082442002403,
-    tokenPoints: 809.8082442002403,
-    referralPoints: 0,
-    rank: "5035",
-    referralRank: "46370",
-    date: "2025-02-12",
-    l2Points: 809.8082442002403,
-    methAmount: 0,
-    cmethAmount: 20.956417664487045,
-  },
-}
-   */
+type PointsData = {
+  walletAddress: string;
+  totalPoints: number;
+  tokenPoints: number;
+  referralPoints: number;
+  rank: string;
+  referralRank: string;
+  date: string;
+  l2Points: number;
+  methAmount: number;
+  cmethAmount: number;
+};
+
+type APIResponse = {
+  message: string;
+  code: number;
+  data: PointsData | null;
+};
+
+const isPointsData = (value: unknown): value is PointsData => {
+  if (!value || typeof value !== "object") return false;
+
+  const data = value as Record<string, unknown>;
+  return (
+    typeof data.walletAddress === "string" &&
+    typeof data.totalPoints === "number" &&
+    typeof data.tokenPoints === "number" &&
+    typeof data.referralPoints === "number" &&
+    typeof data.rank === "string" &&
+    typeof data.referralRank === "string" &&
+    typeof data.date === "string" &&
+    typeof data.l2Points === "number" &&
+    typeof data.methAmount === "number" &&
+    typeof data.cmethAmount === "number"
+  );
+};
+
 export default {
   fetch: async (address: string) => {
-    const res = await fetch(
+    const response = await fetch(
       API_URL.replace("{address}", address.toLowerCase()),
-      {
-        headers: {
-          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
-        },
-      }
     );
-    const data = await res.json();
-    return data.data;
+    if (!response.ok) {
+      throw new Error(
+        `mETH Protocol request failed with status ${response.status}`,
+      );
+    }
+
+    let responseData: unknown;
+    try {
+      responseData = await response.json();
+    } catch {
+      throw new Error("mETH Protocol returned an invalid JSON response");
+    }
+
+    if (!responseData || typeof responseData !== "object") {
+      throw new Error("mETH Protocol returned a malformed response");
+    }
+
+    const result = responseData as Partial<APIResponse>;
+    if (result.code !== 0 || !("data" in result)) {
+      throw new Error("mETH Protocol returned a malformed points response");
+    }
+
+    const pointsData = result.data;
+    if (pointsData !== null && !isPointsData(pointsData)) {
+      throw new Error("mETH Protocol returned a malformed points response");
+    }
+
+    return pointsData;
   },
-  data: (data: Record<string, string | number> | null) => {
+  data: (data: PointsData | null) => {
     return data
       ? {
-          "Total Points": data.totalPoints,
-          "Token Points": data.tokenPoints,
-          "Referral Points": data.referralPoints,
-          Rank: data.rank,
-          "Referral Rank": data.referralRank,
-          Date: data.date,
-          "L2 Points": data.l2Points,
-          "mETH Amount": data.methAmount,
-          "cmETH Amount": data.cmethAmount,
-        }
+        "Total Points": data.totalPoints,
+        "Token Points": data.tokenPoints,
+        "Referral Points": data.referralPoints,
+        Rank: data.rank,
+        "Referral Rank": data.referralRank,
+        Date: data.date,
+        "L2 Points": data.l2Points,
+        "mETH Amount": data.methAmount,
+        "cmETH Amount": data.cmethAmount,
+      }
       : {};
   },
-  total: (data: { totalPoints?: number } | null) => data?.totalPoints ?? 0,
-  rank: (data: { rank?: string }) => parseInt(data?.rank || "0"),
+  total: (data: PointsData | null) => data?.totalPoints ?? 0,
+  rank: (data: PointsData | null) => parseInt(data?.rank || "0"),
+  deprecated: () => ({
+    Points: 1758412800, // September 21st 2025 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/nado.ts
+++ b/adapters/nado.ts
@@ -1,10 +1,7 @@
 import { formatUnits, getAddress } from "viem";
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const ARCHIVE_URL = await maybeWrapCORSProxy(
-  "https://archive.prod.nado.xyz/v1",
-);
+const REWARDS_URL = "https://api.prod.nado.xyz/rewards/v1";
 
 type PointsBreakdown = {
   points: string;
@@ -27,6 +24,7 @@ type API_RESPONSE = PointsResponse;
 const headers = {
   accept: "application/json",
   "content-type": "application/json",
+  "x-nado-client-type": "nado",
 };
 
 const toPointsNumber = (value: string | undefined): number => {
@@ -40,8 +38,30 @@ const buildPointsBreakdown = (points: PointsBreakdown) => ({
   Tier: points.tier,
 });
 
+const isPointsBreakdown = (value: unknown): value is PointsBreakdown => {
+  if (!value || typeof value !== "object") return false;
+
+  const points = value as Record<string, unknown>;
+  return typeof points.points === "string" &&
+    typeof points.rank === "number" &&
+    typeof points.tier === "number";
+};
+
+const isPointsResponse = (value: unknown): value is PointsResponse => {
+  if (!value || typeof value !== "object") return false;
+
+  const response = value as Record<string, unknown>;
+  return Array.isArray(response.points_per_epoch) &&
+    response.points_per_epoch.every((epoch) => {
+      if (!isPointsBreakdown(epoch)) return false;
+      const pointsEpoch = epoch as unknown as Record<string, unknown>;
+      return typeof pointsEpoch.epoch === "number" &&
+        typeof pointsEpoch.description === "string";
+    }) && isPointsBreakdown(response.all_time_points);
+};
+
 const fetchPoints = async (address: string): Promise<PointsResponse> => {
-  const res = await fetch(ARCHIVE_URL, {
+  const res = await fetch(REWARDS_URL, {
     method: "POST",
     headers,
     body: JSON.stringify({
@@ -53,7 +73,18 @@ const fetchPoints = async (address: string): Promise<PointsResponse> => {
     throw new Error(`Nado points request failed with status ${res.status}`);
   }
 
-  return await res.json() as PointsResponse;
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch {
+    throw new Error("Nado points request returned invalid JSON");
+  }
+
+  if (!isPointsResponse(data)) {
+    throw new Error("Nado points request returned a malformed response");
+  }
+
+  return data;
 };
 
 const buildEpochBreakdown = (epochs: PointsEpoch[]) =>

--- a/adapters/pear.ts
+++ b/adapters/pear.ts
@@ -1,8 +1,7 @@
 import { getAddress } from "viem";
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_BASE_URL = await maybeWrapCORSProxy("https://api.fuul.xyz/api/v1");
+const API_BASE_URL = "https://api.fuul.xyz/api/v1";
 
 const SEASONS = [
   {

--- a/adapters/rainbow.ts
+++ b/adapters/rainbow.ts
@@ -1,10 +1,7 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 import { formatEther } from "viem";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://metadata.p.rainbow.me/v1/graph",
-);
+const API_URL = "https://metadata.p.rainbow.me/v1/graph";
 
 type API_RESPONSE = {
   earnings: { total: number };

--- a/adapters/re.ts
+++ b/adapters/re.ts
@@ -1,9 +1,6 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://api.re.xyz/wallet/points?address={address}",
-);
+const API_URL = "https://api.re.xyz/wallet/points?address={address}";
 
 type RePointsResponse = {
   success: boolean;

--- a/adapters/reya.ts
+++ b/adapters/reya.ts
@@ -1,12 +1,9 @@
 import { getAddress } from "viem";
 import type { AdapterExport } from "../utils/adapter.ts";
 
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 import { convertKeysToStartCase } from "../utils/object.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://api.reya.xyz/api/incentives/wallet/{address}"
-);
+const API_URL = "https://api.reya.xyz/api/incentives/wallet/{address}";
 // 0xefcbfd73d67f92b37713e7eb9284e813b8f0e49a
 type API_RESPONSE = {
   points: {

--- a/adapters/shmonad.ts
+++ b/adapters/shmonad.ts
@@ -1,8 +1,7 @@
 import { formatUnits, getAddress } from "viem";
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const MERKL_API_URL = await maybeWrapCORSProxy("https://api.merkl.xyz/v4");
+const MERKL_API_URL = "https://api.merkl.xyz/v4";
 
 const MONAD_CHAIN_ID = 143;
 const SHMON_POINTS_ADDRESS = "0xCdEF0ED16c5800025B26908b3Be9e6Ad4Ef187a5";

--- a/adapters/solv.ts
+++ b/adapters/solv.ts
@@ -1,8 +1,7 @@
 import type { AdapterExport } from "../utils/adapter.ts";
 import { convertKeysToStartCase } from "../utils/object.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy("https://sft-api.com/graphql");
+const API_URL = "https://sft-api.com/graphql";
 // Simply just btoa('undefined||undefined||undefined||') + '.undefined'
 const API_KEY = "dW5kZWZpbmVkfHx1bmRlZmluZWR8fHVuZGVmaW5lZHx8.undefined";
 

--- a/adapters/sonic.ts
+++ b/adapters/sonic.ts
@@ -1,9 +1,7 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://www.data-openblocklabs.com/sonic/user-points-stats?wallet_address={address}",
-);
+const API_URL =
+  "https://www.data-openblocklabs.com/sonic/user-points-stats?wallet_address={address}";
 
 /**
  * {

--- a/adapters/strata.ts
+++ b/adapters/strata.ts
@@ -1,9 +1,7 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://api.strata.money/points/stats?accountAddress={address}&season=1&chainId=1"
-);
+const API_URL =
+  "https://api.strata.money/points/stats?accountAddress={address}&season=1&chainId=1";
 
 type PointBucket = number | number[] | Record<string, number>;
 

--- a/adapters/superform.ts
+++ b/adapters/superform.ts
@@ -1,70 +1,123 @@
 import type { AdapterExport } from "../utils/adapter.ts";
 import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://persephone.superform.xyz/v1/rewards/summary/{address}?epoch={epoch}",
+const FTB_LEADERBOARD_URL = await maybeWrapCORSProxy(
+  "https://app.superform.xyz/api/leaderboard",
 );
 
-const CHECKPOINT_USER_AGENT = "Checkpoint API (https://checkpoint.exchange)";
-
-type SuperformSummary = {
-  user: {
-    points: number;
-    points_per_day: number;
-    referrals_direct: number;
-    referrals_indirect: number;
-    rank: string;
-  };
-  season_1?: { user_points: number };
-  season_2?: { user_points: number };
+type FTBLeaderboardEntry = {
+  wallet_address: string;
+  tier: string;
+  tvl_usd: number;
+  up_usd: number;
+  approved_count: number;
+  pending_count: number;
+  content_points: number;
+  quest_points: number;
+  governance_points: number;
+  achievement_points: number;
+  base_points: number;
+  tier_multiplier: number;
+  boosted_score: number;
+  rank: number;
 };
 
-type SuperformFetchResponse = {
-  epoch2: SuperformSummary;
-  epoch1: SuperformSummary;
-  epoch0: SuperformSummary;
+type API_RESPONSE = {
+  entry?: FTBLeaderboardEntry;
+};
+
+const isLeaderboardEntry = (value: unknown): value is FTBLeaderboardEntry => {
+  if (!value || typeof value !== "object") return false;
+
+  const entry = value as Record<string, unknown>;
+  const numericKeys = [
+    "tvl_usd",
+    "up_usd",
+    "approved_count",
+    "pending_count",
+    "content_points",
+    "quest_points",
+    "governance_points",
+    "achievement_points",
+    "base_points",
+    "tier_multiplier",
+    "boosted_score",
+    "rank",
+  ];
+
+  return typeof entry.wallet_address === "string" &&
+    typeof entry.tier === "string" &&
+    numericKeys.every((key) => {
+      const numericValue = entry[key];
+      return typeof numericValue === "number" &&
+        Number.isFinite(numericValue);
+    });
 };
 
 export default {
-  fetch: async (address: string): Promise<SuperformFetchResponse> => {
-    const fetchSummary = async (epoch: number): Promise<SuperformSummary> => {
-      const url = API_URL.replace("{address}", address).replace(
-        "{epoch}",
-        String(epoch),
+  fetch: async (address: string): Promise<API_RESPONSE> => {
+    const res = await fetch(FTB_LEADERBOARD_URL, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `Superform FTB leaderboard request failed with status ${res.status}`,
       );
+    }
 
-      return await (
-        await fetch(url, {
-          headers: {
-            "User-Agent": CHECKPOINT_USER_AGENT,
-          },
-        })
-      ).json();
-    };
+    let data: unknown;
+    try {
+      data = await res.json();
+    } catch {
+      throw new Error("Superform FTB leaderboard returned invalid JSON");
+    }
 
-    const [epoch2, epoch1, epoch0] = await Promise.all([
-      fetchSummary(2),
-      fetchSummary(1),
-      fetchSummary(0),
-    ]);
+    if (!Array.isArray(data)) {
+      throw new Error(
+        "Superform FTB leaderboard returned a malformed response",
+      );
+    }
 
-    return { epoch2, epoch1, epoch0 };
+    const normalizedAddress = address.toLowerCase();
+    const entry = data.find((value) => {
+      if (!value || typeof value !== "object") return false;
+      const walletAddress = (value as Record<string, unknown>).wallet_address;
+      return typeof walletAddress === "string" &&
+        walletAddress.toLowerCase() === normalizedAddress;
+    });
+
+    if (entry === undefined) return {};
+    if (!isLeaderboardEntry(entry)) {
+      throw new Error(
+        "Superform FTB leaderboard returned malformed data for the wallet",
+      );
+    }
+
+    return { entry };
   },
-  data: ({ epoch2, epoch1, epoch0 }: SuperformFetchResponse) => ({
-    "S3 Epoch 2 Points": epoch2.user.points,
-    "S3 Points": epoch2.user.points,
-    "S2 Cred": epoch2.season_2?.user_points ?? 0,
-    "S1 XP": epoch2.season_1?.user_points ?? 0,
-    "S3 Epoch 1 Points": epoch1.user.points,
-    "S3 Epoch 0 Points": epoch0.user.points,
-    "Points Per Day": epoch2.user.points_per_day,
-    "Referrals Direct": epoch2.user.referrals_direct,
-    "Referrals Indirect": epoch2.user.referrals_indirect,
+  data: ({ entry }: API_RESPONSE) => ({
+    "FTB Points": entry?.boosted_score ?? 0,
+    "Base Points": entry?.base_points ?? 0,
+    "Content Points": entry?.content_points ?? 0,
+    "Quest Points": entry?.quest_points ?? 0,
+    "Governance Points": entry?.governance_points ?? 0,
+    "Achievement Points": entry?.achievement_points ?? 0,
+    "Tier Multiplier": entry?.tier_multiplier ?? 0,
+    Tier: entry?.tier ?? "Unranked",
+    Rank: entry?.rank ?? 0,
+    "TVL USD": entry?.tvl_usd ?? 0,
+    "sUP USD": entry?.up_usd ?? 0,
+    "Approved Submissions": entry?.approved_count ?? 0,
+    "Pending Submissions": entry?.pending_count ?? 0,
   }),
-  total: ({ epoch2 }: SuperformFetchResponse) => ({
-    "S3 Points": epoch2.user.points,
+  total: ({ entry }: API_RESPONSE) => ({
+    "FTB Points": entry?.boosted_score ?? 0,
   }),
-  rank: ({ epoch2 }: SuperformFetchResponse) => Number(epoch2.user.rank),
+  rank: ({ entry }: API_RESPONSE) => entry?.rank ?? 0,
   deprecated: () => ({
     "S3 Points": 1780876800, // June 8th 2026 00:00 UTC
   }),

--- a/adapters/swapx.ts
+++ b/adapters/swapx.ts
@@ -1,60 +1,11 @@
 import type { AdapterExport } from "../utils/adapter.ts";
 
-const API_URL =
-  "https://soft-moon-4fdf.admin-b72.workers.dev/info/user?address={address}&epoch=0";
-
-/**
- * Response format:
- * {
- *   "message": {
- *     "downlines": {"1":[],"2":[],"3":[]},
- *     "userName": null,
- *     "uplineUserName": null,
- *     "lockedSwpxUSD": 91419.28,
- *     "EpochUserStatsXX": [
- *       {"epoch":4,"powerPercentage":0},
- *       {"epoch":5,"powerPercentage":0.28},
- *       {"epoch":6,"powerPercentage":1.91},
- *       {"epoch":7,"powerPercentage":4.38},
- *       {"epoch":8,"powerPercentage":4.5},
- *       {"epoch":9,"powerPercentage":2.56}
- *     ]
- *   },
- *   "success": true
- * }
- */
 export default {
-  fetch: async (address: string) => {
-    const data = await (
-      await fetch(API_URL.replace("{address}", address.toLowerCase()), {
-        headers: {
-          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
-        },
-      })
-    ).json();
-
-    if (!data.success || typeof data.message === "string") {
-      return { lockedSwpxUSD: 0, EpochUserStatsXX: [] };
-    }
-
-    return data.message;
-  },
-  data: ({
-    lockedSwpxUSD,
-    EpochUserStatsXX,
-  }: {
-    lockedSwpxUSD: number;
-    EpochUserStatsXX: Array<{ epoch: number; powerPercentage: number }>;
-  }) => {
-    const epochData = Object.fromEntries(
-      EpochUserStatsXX.map(({ epoch, powerPercentage }) => [
-        `Epoch ${epoch}`,
-        powerPercentage,
-      ])
-    );
-
-    return { lockedSwpxUSD, ...epochData };
-  },
-  total: ({ lockedSwpxUSD }: { lockedSwpxUSD: number }) => lockedSwpxUSD,
+  fetch: async () => await Promise.resolve({}),
+  data: () => ({}),
+  total: () => 0,
+  deprecated: () => ({
+    Points: 1766448000, // December 23rd 2025 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/symbiotic.ts
+++ b/adapters/symbiotic.ts
@@ -1,9 +1,7 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://api.symbiotic.fi/api/v1/points/receiver/{address}/current",
-);
+const API_URL =
+  "https://api.symbiotic.fi/api/v1/points/receiver/{address}/current";
 
 interface PointsData {
   points_type: string;

--- a/adapters/theleaderboard.ts
+++ b/adapters/theleaderboard.ts
@@ -1,9 +1,6 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://mini.frm.lol/api/mini/leaderboard/rank/{fid}"
-);
+const API_URL = "https://mini.frm.lol/api/mini/leaderboard/rank/{fid}";
 
 type LeaderboardData = {
   points: number;

--- a/adapters/valantis.ts
+++ b/adapters/valantis.ts
@@ -1,89 +1,11 @@
-import { getAddress } from "viem";
 import type { AdapterExport } from "../utils/adapter.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
-
-const API_BASE_URL = await maybeWrapCORSProxy(
-  "https://analytics-v3.valantis-analytics.xyz",
-);
-
-const POINTS_BEARER = "f2ffd7876ec03f1f4a04ed88402b1802";
-
-const headers = {
-  accept: "application/json",
-  authorization: `Bearer ${POINTS_BEARER}`,
-  "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
-};
-
-type LeaderboardEntry = {
-  total_amount?: number | string;
-  total?: number;
-  rank?: number;
-  total_attributions?: number;
-};
-
-type LeaderboardResponse = {
-  results?: LeaderboardEntry[];
-  total_results?: number;
-  calculated_at?: string;
-};
-
-type API_RESPONSE = {
-  leaderboard: LeaderboardEntry;
-  leaderboardTotal: number;
-  calculatedAt?: string;
-};
-
-const emptyLeaderboard = (): LeaderboardEntry => ({
-  total_amount: 0,
-  total: 0,
-  rank: 0,
-  total_attributions: 0,
-});
-
-const toNumber = (value: number | string | undefined): number => {
-  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
-  if (!value) return 0;
-  return Number(value) || 0;
-};
-
-const fetchJson = async <T>(path: string): Promise<T> => {
-  const res = await fetch(`${API_BASE_URL}${path}`, { headers });
-
-  if (res.status === 404) {
-    return { results: [], total_results: 0 } as T;
-  }
-
-  if (!res.ok) {
-    throw new Error(`Valantis request failed with status ${res.status}`);
-  }
-
-  return await res.json() as T;
-};
-
-const getLeaderboardTotal = (response: API_RESPONSE): number =>
-  toNumber(response.leaderboard.total_amount);
 
 export default {
-  fetch: async (address: string) => {
-    const normalizedAddress = getAddress(address).toLowerCase();
-    const params = new URLSearchParams({ user_identifier: normalizedAddress });
-
-    const leaderboard = await fetchJson<LeaderboardResponse>(
-      `/api/v1/payouts/leaderboard/points?${params}`,
-    );
-
-    return {
-      leaderboard: leaderboard.results?.[0] ?? emptyLeaderboard(),
-      leaderboardTotal: Number(leaderboard.total_results ?? 0),
-      calculatedAt: leaderboard.calculated_at,
-    };
-  },
-  data: (response: API_RESPONSE) => ({
-    Points: getLeaderboardTotal(response),
-    Rank: Number(response.leaderboard.rank ?? 0),
-    "Leaderboard Total": response.leaderboardTotal,
+  fetch: async () => await Promise.resolve({}),
+  data: () => ({}),
+  total: () => 0,
+  deprecated: () => ({
+    Points: 1780531200, // June 4th 2026 00:00 UTC
   }),
-  total: (response: API_RESPONSE) => getLeaderboardTotal(response),
-  rank: (response: API_RESPONSE) => Number(response.leaderboard.rank ?? 0),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Superform’s FTB leaderboard metrics, including scores, tiers, rankings, and multipliers.
  - Improved points data validation for mETH Protocol and Nado, with clearer errors for invalid responses.

- **Bug Fixes**
  - Improved request handling and validation for Bedrock data.
  - Updated several integrations to connect more reliably to their data services.

- **Deprecations**
  - Marked multiple points programs as deprecated with their applicable end dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->