### PR TITLE
Add Blinq points adapter

### DIFF
--- a/adapters/blinq.ts
+++ b/adapters/blinq.ts
@@ -1,0 +1,62 @@
+import { titleCase } from "text-case";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://beta.api.blinq.fi/reward-service/api/rewards/points/{address}",
+);
+
+type BlinqPointsBreakdown = {
+  point_type: string;
+  total_rewards: string;
+};
+
+type BlinqPointsResponse = {
+  block_checkpoint?: number;
+  breakup?: BlinqPointsBreakdown[];
+  total_rewards?: string;
+  updated_at?: string;
+  wallet_address?: string;
+};
+
+const getPoints = (data: BlinqPointsResponse): number =>
+  Number(data.total_rewards ?? 0) || 0;
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = address.toLowerCase();
+    const res = await fetch(API_URL.replace("{address}", normalizedAddress), {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (res.status === 404) {
+      return {
+        breakup: [],
+        total_rewards: "0",
+        wallet_address: normalizedAddress,
+      } as BlinqPointsResponse;
+    }
+
+    if (!res.ok) {
+      throw new Error(`Blinq points request failed with status ${res.status}`);
+    }
+
+    return await res.json() as BlinqPointsResponse;
+  },
+  data: (data: BlinqPointsResponse) => ({
+    "Blinq Points": getPoints(data),
+    ...Object.fromEntries(
+      (data.breakup ?? []).map(({ point_type, total_rewards }) => [
+        `${titleCase(point_type)} Points`,
+        Number(total_rewards) || 0,
+      ]),
+    ),
+    "Last Updated": data.updated_at ?? "N/A",
+    "Block Checkpoint": data.block_checkpoint ?? "N/A",
+  }),
+  total: getPoints,
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving Blinq wallet reward points.
  - Displays total points and point breakdowns by reward type.
  - Supports EVM wallet addresses.
  - Includes reward update metadata.
  - Treats wallets with no Blinq record as having zero points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->