### PR TITLE
Add Canopy points adapter

### DIFF
--- a/adapters/canopy.ts
+++ b/adapters/canopy.ts
@@ -1,0 +1,52 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const WEBSITE_ID = "c52fecd3-3906-445b-90ed-6758fc3804cb";
+const ORGANIZATION_ID = "dac5bd9d-dbc7-4932-a767-7447d364a9f7";
+const LOYALTY_CURRENCY_ID = "aab6646e-449f-4395-bc2b-290ffec002fc";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://admin.snagsolutions.io/api/loyalty/accounts" +
+    `?websiteId=${WEBSITE_ID}` +
+    `&organizationId=${ORGANIZATION_ID}` +
+    `&loyaltyCurrencyId=${LOYALTY_CURRENCY_ID}` +
+    "&walletAddress={address}" +
+    "&limit=1",
+);
+
+type CanopyAccount = {
+  amount?: string;
+  updatedAt?: string;
+};
+
+type CanopyResponse = {
+  data?: CanopyAccount[];
+};
+
+const getPoints = (data: CanopyResponse): number =>
+  Number(data.data?.[0]?.amount ?? 0) || 0;
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const res = await fetch(API_URL.replace("{address}", normalizedAddress), {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Canopy points request failed with status ${res.status}`);
+    }
+
+    return await res.json() as CanopyResponse;
+  },
+  data: (data: CanopyResponse) => ({
+    "Canopy Points": getPoints(data),
+    "Last Updated": data.data?.[0]?.updatedAt ?? "N/A",
+  }),
+  total: getPoints,
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/canopy.ts
+++ b/adapters/canopy.ts
@@ -24,8 +24,21 @@ type CanopyResponse = {
   data?: CanopyAccount[];
 };
 
-const getPoints = (data: CanopyResponse): number =>
-  Number(data.data?.[0]?.amount ?? 0) || 0;
+const getPoints = (data: CanopyResponse): number => {
+  const account = data.data?.[0];
+  if (!account) return 0;
+
+  if (!account.amount?.trim()) {
+    throw new Error("Canopy account response has no amount");
+  }
+
+  const points = Number(account.amount);
+  if (!Number.isFinite(points)) {
+    throw new Error("Canopy account amount is not finite");
+  }
+
+  return points;
+};
 
 export default {
   fetch: async (address: string) => {


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Canopy loyalty account support for EVM addresses.
  - Canopy account information now includes current points, total points, and last-updated details.
  - Addresses are normalized and responses are validated for more consistent account data.
  - Account amounts now return zero only when no account exists; unavailable or invalid values are reported as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->