### PR TITLE
Add kintsu adapter

### DIFF
--- a/adapters/kintsu.ts
+++ b/adapters/kintsu.ts
@@ -9,7 +9,6 @@ const API_URL = await maybeWrapCORSProxy(
 const USER_POINTS_QUERY = `
   query UsersPoints($walletAddress: String!) {
     User_Points(where: { id: { _ilike: $walletAddress } }) {
-      id
       totalPoints
       ranking
       percentile
@@ -18,7 +17,6 @@ const USER_POINTS_QUERY = `
 `;
 
 type KintsuPointsEntry = {
-  id?: unknown;
   totalPoints?: unknown;
   ranking?: unknown;
   percentile?: unknown;
@@ -31,22 +29,14 @@ type KintsuResponse = {
   errors?: Array<{ message?: string }>;
 };
 
-type KintsuPoints = {
-  points: number;
-  rank: number;
-  percentile: number;
-};
-
-const emptyPoints = (): KintsuPoints => ({
-  points: 0,
-  rank: 0,
-  percentile: 0,
-});
-
-const parseNumber = (
-  value: unknown,
-  field: string,
+const getValue = (
+  data: KintsuResponse,
+  field: keyof KintsuPointsEntry,
 ): number => {
+  const account = data.data?.User_Points?.[0];
+  if (!account) return 0;
+
+  const value = account[field];
   if (
     (typeof value !== "string" && typeof value !== "number") ||
     (typeof value === "string" && !value.trim())
@@ -60,39 +50,6 @@ const parseNumber = (
   }
 
   return parsed;
-};
-
-const parseEntry = (
-  entry: KintsuPointsEntry,
-  address: string,
-): KintsuPoints => {
-  if (
-    typeof entry.id !== "string" ||
-    entry.id.toLowerCase() !== address.toLowerCase()
-  ) {
-    throw new Error("Kintsu response returned a different wallet");
-  }
-
-  const rank = parseNumber(entry.ranking, "rank");
-  if (!Number.isSafeInteger(rank)) {
-    throw new Error("Kintsu response has invalid rank");
-  }
-
-  const percentile = parseNumber(entry.percentile, "percentile");
-  if (percentile > 100) {
-    throw new Error("Kintsu response has invalid percentile");
-  }
-
-  const points = parseNumber(entry.totalPoints, "points");
-  if (!Number.isSafeInteger(points)) {
-    throw new Error("Kintsu response has invalid points");
-  }
-
-  return {
-    points,
-    rank,
-    percentile,
-  };
 };
 
 export default {
@@ -128,19 +85,15 @@ export default {
     if (!Array.isArray(entries)) {
       throw new Error("Kintsu response has no points data");
     }
-    if (entries.length > 1) {
-      throw new Error("Kintsu response returned multiple wallets");
-    }
 
-    const entry = entries[0];
-    return entry ? parseEntry(entry, normalizedAddress) : emptyPoints();
+    return response;
   },
-  data: ({ points, rank, percentile }: KintsuPoints) => ({
-    "Kintsu Points": points,
-    Rank: rank,
-    Percentile: percentile,
+  data: (data: KintsuResponse) => ({
+    "Kintsu Points": getValue(data, "totalPoints"),
+    Rank: getValue(data, "ranking"),
+    Percentile: getValue(data, "percentile"),
   }),
-  total: ({ points }: KintsuPoints) => points,
-  rank: ({ rank }: KintsuPoints) => rank,
+  total: (data: KintsuResponse) => getValue(data, "totalPoints"),
+  rank: (data: KintsuResponse) => getValue(data, "ranking"),
   supportedAddressTypes: ["evm"],
-} satisfies AdapterExport<KintsuPoints>;
+} satisfies AdapterExport<KintsuResponse>;

--- a/adapters/kintsu.ts
+++ b/adapters/kintsu.ts
@@ -1,0 +1,146 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://www.kintsu.xyz/api/graphql",
+);
+
+const USER_POINTS_QUERY = `
+  query UsersPoints($walletAddress: String!) {
+    User_Points(where: { id: { _ilike: $walletAddress } }) {
+      id
+      totalPoints
+      ranking
+      percentile
+    }
+  }
+`;
+
+type KintsuPointsEntry = {
+  id?: unknown;
+  totalPoints?: unknown;
+  ranking?: unknown;
+  percentile?: unknown;
+};
+
+type KintsuResponse = {
+  data?: {
+    User_Points?: KintsuPointsEntry[];
+  };
+  errors?: Array<{ message?: string }>;
+};
+
+type KintsuPoints = {
+  points: number;
+  rank: number;
+  percentile: number;
+};
+
+const emptyPoints = (): KintsuPoints => ({
+  points: 0,
+  rank: 0,
+  percentile: 0,
+});
+
+const parseNumber = (
+  value: unknown,
+  field: string,
+): number => {
+  if (
+    (typeof value !== "string" && typeof value !== "number") ||
+    (typeof value === "string" && !value.trim())
+  ) {
+    throw new Error(`Kintsu response has no ${field}`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Kintsu response has invalid ${field}`);
+  }
+
+  return parsed;
+};
+
+const parseEntry = (
+  entry: KintsuPointsEntry,
+  address: string,
+): KintsuPoints => {
+  if (
+    typeof entry.id !== "string" ||
+    entry.id.toLowerCase() !== address.toLowerCase()
+  ) {
+    throw new Error("Kintsu response returned a different wallet");
+  }
+
+  const rank = parseNumber(entry.ranking, "rank");
+  if (!Number.isSafeInteger(rank)) {
+    throw new Error("Kintsu response has invalid rank");
+  }
+
+  const percentile = parseNumber(entry.percentile, "percentile");
+  if (percentile > 100) {
+    throw new Error("Kintsu response has invalid percentile");
+  }
+
+  const points = parseNumber(entry.totalPoints, "points");
+  if (!Number.isSafeInteger(points)) {
+    throw new Error("Kintsu response has invalid points");
+  }
+
+  return {
+    points,
+    rank,
+    percentile,
+  };
+};
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address);
+    const res = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+      body: JSON.stringify({
+        query: USER_POINTS_QUERY,
+        variables: { walletAddress: normalizedAddress },
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Kintsu request failed with status ${res.status}`);
+    }
+
+    const response = await res.json() as KintsuResponse;
+    if (response.errors?.length) {
+      throw new Error(
+        `Kintsu request failed: ${
+          response.errors[0]?.message ?? "unknown error"
+        }`,
+      );
+    }
+
+    const entries = response.data?.User_Points;
+    if (!Array.isArray(entries)) {
+      throw new Error("Kintsu response has no points data");
+    }
+    if (entries.length > 1) {
+      throw new Error("Kintsu response returned multiple wallets");
+    }
+
+    const entry = entries[0];
+    return entry ? parseEntry(entry, normalizedAddress) : emptyPoints();
+  },
+  data: ({ points, rank, percentile }: KintsuPoints) => ({
+    "Kintsu Points": points,
+    Rank: rank,
+    Percentile: percentile,
+  }),
+  total: ({ points }: KintsuPoints) => points,
+  rank: ({ rank }: KintsuPoints) => rank,
+  supportedAddressTypes: ["evm"],
+} satisfies AdapterExport<KintsuPoints>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving Kintsu points data using EVM wallet addresses.
  - Displays normalized points totals, ranks, and percentile information.
  - Added validation to ensure wallet addresses and returned points data are valid.
  - Supports optional network proxy configuration for accessing the Kintsu service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->