### PR TITLE
Add Aegis points adapter

### DIFF
--- a/adapters/aegis.ts
+++ b/adapters/aegis.ts
@@ -1,0 +1,87 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+
+const API_URL = "https://api.fuul.xyz/api/v1/payouts/leaderboard/points";
+const API_KEY =
+  "9f1c522a29a7ea0c75dce00e561b6624333360751e8378f69cc40f95288a8c7c";
+
+type LeaderboardEntry = {
+  address?: unknown;
+  total_amount?: unknown;
+  rank?: unknown;
+};
+
+const getNumber = (
+  entry: LeaderboardEntry | undefined,
+  field: "total_amount" | "rank",
+): number => {
+  if (!entry) return 0;
+
+  const value = entry[field];
+  if (
+    (typeof value !== "number" && typeof value !== "string") ||
+    (typeof value === "string" && !value.trim())
+  ) {
+    throw new Error(`Aegis response has no ${field}`);
+  }
+
+  const parsed = Number(value);
+  if (
+    !Number.isFinite(parsed) ||
+    parsed < 0 ||
+    (field === "rank" && (!Number.isInteger(parsed) || parsed === 0))
+  ) {
+    throw new Error(`Aegis response has invalid ${field}`);
+  }
+
+  return parsed;
+};
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const res = await fetch(
+      `${API_URL}?user_identifier=${normalizedAddress}&user_identifier_type=evm_address&page=1&page_size=1`,
+      {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${API_KEY}`,
+          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+        },
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error(`Aegis request failed with status ${res.status}`);
+    }
+
+    const response = await res.json() as { results?: unknown };
+    if (!Array.isArray(response.results)) {
+      throw new Error("Aegis response has no leaderboard results");
+    }
+
+    const entry = response.results[0];
+    if (entry === undefined) return undefined;
+    if (!entry || typeof entry !== "object") {
+      throw new Error("Aegis response has an invalid leaderboard entry");
+    }
+
+    const leaderboardEntry = entry as LeaderboardEntry;
+    if (
+      typeof leaderboardEntry.address !== "string" ||
+      leaderboardEntry.address.toLowerCase() !== normalizedAddress
+    ) {
+      throw new Error("Aegis response returned a different wallet");
+    }
+
+    return leaderboardEntry;
+  },
+  data: (entry: LeaderboardEntry | undefined) => ({
+    "Season 2 Points": getNumber(entry, "total_amount"),
+    Rank: getNumber(entry, "rank"),
+  }),
+  total: (entry: LeaderboardEntry | undefined) =>
+    getNumber(entry, "total_amount"),
+  rank: (entry: LeaderboardEntry | undefined) => getNumber(entry, "rank"),
+  supportedAddressTypes: ["evm"],
+} satisfies AdapterExport<LeaderboardEntry | undefined>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving leaderboard points, totals, and rankings for EVM addresses through the Aegis integration.
  - Added validation for leaderboard responses and address matching.
  - Empty leaderboards are handled without returning an entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->