### PR TITLE
Add xStocks points adapter

### DIFF
--- a/adapters/xstocks.ts
+++ b/adapters/xstocks.ts
@@ -1,0 +1,87 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://points-api.xstocks.fi/api/v1/xdrop-user/{address}/dashboard",
+);
+
+type XStocksData = {
+  walletAddress?: unknown;
+  totalPoints?: unknown;
+  todayPoints?: unknown;
+  referralPoints?: unknown;
+  xboostMultiplier?: unknown;
+};
+
+const getNumber = (
+  data: XStocksData | undefined,
+  field: Exclude<keyof XStocksData, "walletAddress">,
+): number => {
+  if (!data) return 0;
+
+  const value = data[field];
+  if (
+    (typeof value !== "number" && typeof value !== "string") ||
+    (typeof value === "string" && !value.trim())
+  ) {
+    throw new Error(`xStocks response has no ${field}`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`xStocks response has invalid ${field}`);
+  }
+
+  return parsed;
+};
+
+const normalizeAddress = (address: string): string =>
+  address.startsWith("0x") ? getAddress(address).toLowerCase() : address;
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = normalizeAddress(address);
+    const res = await fetch(
+      API_URL.replace("{address}", encodeURIComponent(normalizedAddress)),
+      {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+        },
+      },
+    );
+
+    if (res.status === 404) return undefined;
+    if (!res.ok) {
+      throw new Error(`xStocks request failed with status ${res.status}`);
+    }
+
+    const response = await res.json() as { success?: unknown; data?: unknown };
+    if (
+      response.success !== true ||
+      !response.data ||
+      typeof response.data !== "object"
+    ) {
+      throw new Error("xStocks response has invalid data");
+    }
+
+    const data = response.data as XStocksData;
+    if (
+      typeof data.walletAddress !== "string" ||
+      normalizeAddress(data.walletAddress) !== normalizedAddress
+    ) {
+      throw new Error("xStocks response returned a different wallet");
+    }
+
+    return data;
+  },
+  data: (data: XStocksData | undefined) => ({
+    xPoints: getNumber(data, "totalPoints"),
+    "Today's xPoints": getNumber(data, "todayPoints"),
+    "Referral xPoints": getNumber(data, "referralPoints"),
+    "xBoost Multiplier": getNumber(data, "xboostMultiplier"),
+  }),
+  total: (data: XStocksData | undefined) => getNumber(data, "totalPoints"),
+  supportedAddressTypes: ["evm", "svm"],
+} satisfies AdapterExport<XStocksData | undefined>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying xStocks points data in user dashboards.
  - Users can view total points, points earned today, referral points, and the xBoost multiplier.
  - Supports both EVM and SVM wallet addresses.
  - Invalid or unavailable points data is handled safely without displaying incorrect results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->