### PR TITLE
Add Noon points adapter

### DIFF
--- a/adapters/noon.ts
+++ b/adapters/noon.ts
@@ -1,0 +1,99 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+
+const API_URL = "https://back.noon.capital/api/v1/points/{address}";
+const FIRST_API_SEASON_MONTH = 2025 * 12 + 5; // API bucket 1: June 2025
+
+type NoonSeason = {
+  total?: unknown;
+};
+
+type NoonProtocol = {
+  bySeasons?: Record<string, NoonSeason>;
+};
+
+type NoonResponse = {
+  byChain?: Record<
+    string,
+    { byProtocol?: Record<string, NoonProtocol> }
+  >;
+};
+
+const getCurrentSeason = (): string => {
+  const now = new Date();
+  const currentMonth = now.getUTCFullYear() * 12 + now.getUTCMonth();
+  return String(currentMonth - FIRST_API_SEASON_MONTH + 1);
+};
+
+const getPoints = (data: NoonResponse | undefined): number => {
+  if (!data) return 0;
+  if (!data.byChain || typeof data.byChain !== "object") {
+    throw new Error("Noon response has invalid chain data");
+  }
+
+  const protocols = Object.values(data.byChain).flatMap((chain) => {
+    if (!chain?.byProtocol || typeof chain.byProtocol !== "object") {
+      throw new Error("Noon response has invalid protocol data");
+    }
+
+    return Object.values(chain.byProtocol);
+  });
+  if (!protocols.length) return 0;
+
+  const currentSeason = getCurrentSeason();
+  return protocols.reduce((total, protocol) => {
+    if (!protocol?.bySeasons || typeof protocol.bySeasons !== "object") {
+      throw new Error("Noon response has invalid season data");
+    }
+
+    const season = protocol.bySeasons?.[currentSeason];
+    if (!season) return total;
+
+    const value = season.total;
+    if (
+      (typeof value !== "number" && typeof value !== "string") ||
+      (typeof value === "string" && !value.trim())
+    ) {
+      throw new Error("Noon response has no season total");
+    }
+
+    const points = Number(value);
+    if (!Number.isFinite(points) || points < 0) {
+      throw new Error("Noon response has invalid season total");
+    }
+
+    return total + points;
+  }, 0);
+};
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const res = await fetch(
+      API_URL.replace("{address}", normalizedAddress),
+      {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+        },
+      },
+    );
+
+    if (res.status === 404) return undefined;
+    if (!res.ok) {
+      throw new Error(`Noon request failed with status ${res.status}`);
+    }
+
+    const data = await res.json();
+    if (!data || typeof data !== "object") {
+      throw new Error("Noon response has invalid data");
+    }
+
+    return data as NoonResponse;
+  },
+  data: (data: NoonResponse | undefined) => ({
+    "Current Season Points": getPoints(data),
+  }),
+  total: getPoints,
+  supportedAddressTypes: ["evm"],
+} satisfies AdapterExport<NoonResponse | undefined>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fetching Noon Capital points.
  - Displays current-season points calculated from protocol-level season totals.
  - Supports normalized EVM wallet addresses.
  - Handles unavailable accounts and invalid responses safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->