### PR TITLE
Add Upshift points adapter

### DIFF
--- a/adapters/upshift.ts
+++ b/adapters/upshift.ts
@@ -1,0 +1,56 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://api.upshift.finance/v1/points/{address}",
+);
+
+type UpshiftResponse = {
+  totalPoints?: unknown;
+};
+
+const getPoints = (data: UpshiftResponse): number => {
+  const value = data.totalPoints;
+  if (
+    (typeof value !== "number" && typeof value !== "string") ||
+    (typeof value === "string" && !value.trim())
+  ) {
+    throw new Error("Upshift response has no total points");
+  }
+
+  const points = Number(value);
+  if (!Number.isFinite(points) || points < 0) {
+    throw new Error("Upshift response has invalid total points");
+  }
+
+  return points;
+};
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const res = await fetch(API_URL.replace("{address}", normalizedAddress), {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Upshift request failed with status ${res.status}`);
+    }
+
+    const data = await res.json();
+    if (!data || typeof data !== "object") {
+      throw new Error("Upshift response has invalid data");
+    }
+
+    return data as UpshiftResponse;
+  },
+  data: (data: UpshiftResponse) => ({
+    "Upshift Points": getPoints(data),
+  }),
+  total: getPoints,
+  supportedAddressTypes: ["evm"],
+} satisfies AdapterExport<UpshiftResponse>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and displaying Upshift Points.
  * Added validation for wallet addresses and returned points data.
  * Support is available for EVM-compatible wallet addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->