### PR TITLE
feat: add GMTrade points adapter

### DIFF
--- a/adapters/gmtrade.ts
+++ b/adapters/gmtrade.ts
@@ -1,0 +1,113 @@
+import { formatUnits } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+
+const API_URL =
+  "https://gmx-solana-sqd.squids.live/gmx-solana-base:prod/api/graphql";
+const GT_DECIMALS = 7;
+
+const USER_GT_QUERY = `
+  query GetUserGtInfo($userAddress: String!) {
+    userGtInfos(where: { id_eq: $userAddress }) {
+      id
+      gt
+      gtRank
+    }
+  }
+`;
+
+type GMTradeEntry = {
+  id?: unknown;
+  gt?: unknown;
+  gtRank?: unknown;
+};
+
+type GMTradeResponse = {
+  data?: { userGtInfos?: unknown };
+  errors?: Array<{ message?: string }>;
+};
+
+const getPoints = (entry: GMTradeEntry | undefined): number => {
+  if (!entry) return 0;
+  if (typeof entry.gt !== "string" || !/^\d+$/.test(entry.gt)) {
+    throw new Error("GMTrade response has invalid GT holdings");
+  }
+
+  const points = Number(formatUnits(BigInt(entry.gt), GT_DECIMALS));
+  if (!Number.isFinite(points) || points < 0) {
+    throw new Error("GMTrade response has invalid GT holdings");
+  }
+
+  return points;
+};
+
+const getRank = (entry: GMTradeEntry | undefined): number => {
+  if (!entry) return 0;
+
+  if (
+    (typeof entry.gtRank !== "string" && typeof entry.gtRank !== "number") ||
+    (typeof entry.gtRank === "string" && !entry.gtRank.trim())
+  ) {
+    throw new Error("GMTrade response has invalid rank");
+  }
+
+  const rank = Number(entry.gtRank);
+  if (!Number.isInteger(rank) || rank <= 0) {
+    throw new Error("GMTrade response has invalid rank");
+  }
+
+  return rank;
+};
+
+export default {
+  fetch: async (address: string) => {
+    const res = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+      body: JSON.stringify({
+        query: USER_GT_QUERY,
+        variables: { userAddress: address },
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`GMTrade request failed with status ${res.status}`);
+    }
+
+    const response = await res.json() as GMTradeResponse;
+    if (response.errors?.length) {
+      throw new Error(
+        `GMTrade request failed: ${
+          response.errors[0]?.message ?? "unknown error"
+        }`,
+      );
+    }
+
+    const entries = response.data?.userGtInfos;
+    if (!Array.isArray(entries)) {
+      throw new Error("GMTrade response has no points data");
+    }
+    if (!entries.length) return undefined;
+
+    const rawEntry = entries[0];
+    if (!rawEntry || typeof rawEntry !== "object") {
+      throw new Error("GMTrade response has invalid points data");
+    }
+
+    const entry = rawEntry as GMTradeEntry;
+    if (entry.id !== address) {
+      throw new Error("GMTrade response returned a different wallet");
+    }
+
+    return entry;
+  },
+  data: (entry: GMTradeEntry | undefined) => ({
+    "GT Holdings": getPoints(entry),
+  }),
+  total: getPoints,
+  rank: getRank,
+  supportedAddressTypes: ["svm"],
+} satisfies AdapterExport<GMTradeEntry | undefined>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving GMTrade holdings and rank information for Solana wallet addresses.
  * Displays holdings as points, along with total points and leaderboard rank.
  * Handles wallets without available GMTrade data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->