### PR TITLE
feat: add Fortytwo points adapter

### DIFF
--- a/adapters/fortytwo.ts
+++ b/adapters/fortytwo.ts
@@ -1,0 +1,80 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://8vcuob4bv8.execute-api.us-east-2.amazonaws.com/leaderboard_v2",
+);
+
+type FortytwoEntry = {
+  original?: unknown;
+  total_reward?: unknown;
+  rank?: unknown;
+};
+
+const getNumber = (
+  entry: FortytwoEntry | undefined,
+  field: "total_reward" | "rank",
+): number => {
+  if (!entry) return 0;
+
+  const value = entry[field];
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`Fortytwo response has invalid ${field}`);
+  }
+  if (field === "rank" && (!Number.isInteger(value) || value === 0)) {
+    throw new Error("Fortytwo response has invalid rank");
+  }
+
+  return value;
+};
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const params = new URLSearchParams({
+      period: "all_time",
+      page: "1",
+      size: "1",
+      wallet_filter: normalizedAddress,
+    });
+    const res = await fetch(`${API_URL}?${params}`, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Fortytwo request failed with status ${res.status}`);
+    }
+
+    const response = await res.json() as { results?: unknown };
+    if (!Array.isArray(response.results)) {
+      throw new Error("Fortytwo response has no leaderboard results");
+    }
+
+    const entry = response.results[0];
+    if (entry === undefined) return undefined;
+    if (!entry || typeof entry !== "object") {
+      throw new Error("Fortytwo response has an invalid leaderboard entry");
+    }
+
+    const fortytwoEntry = entry as FortytwoEntry;
+    if (
+      typeof fortytwoEntry.original !== "string" ||
+      fortytwoEntry.original.toLowerCase() !== normalizedAddress
+    ) {
+      throw new Error("Fortytwo response returned a different wallet");
+    }
+
+    return fortytwoEntry;
+  },
+  data: (entry: FortytwoEntry | undefined) => ({
+    "FOR Points": getNumber(entry, "total_reward"),
+    Rank: getNumber(entry, "rank"),
+  }),
+  total: (entry: FortytwoEntry | undefined) => getNumber(entry, "total_reward"),
+  rank: (entry: FortytwoEntry | undefined) => getNumber(entry, "rank"),
+  supportedAddressTypes: ["evm"],
+} satisfies AdapterExport<FortytwoEntry | undefined>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving all-time Fortytwo leaderboard rewards and rankings.
  - EVM wallet addresses are supported, with validated wallet identity, reward, and rank information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->