### PR TITLE
feat: add Zerion XP adapter

### DIFF
--- a/adapters/zerion.ts
+++ b/adapters/zerion.ts
@@ -1,0 +1,75 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+
+const API_URL = "https://dna.zerion.io/api/v1/leaders/{address}";
+
+type ZerionEntry = {
+  wallet?: unknown;
+  earnedXP?: unknown;
+  level?: unknown;
+  position?: unknown;
+};
+
+const getNumber = (
+  entry: ZerionEntry | undefined,
+  field: "earnedXP" | "level" | "position",
+): number => {
+  if (!entry) return 0;
+
+  const value = entry[field];
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`Zerion response has invalid ${field}`);
+  }
+  if (
+    field !== "earnedXP" &&
+    (!Number.isInteger(value) || (field === "position" && value === 0))
+  ) {
+    throw new Error(`Zerion response has invalid ${field}`);
+  }
+
+  return value;
+};
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const res = await fetch(API_URL.replace("{address}", normalizedAddress), {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (res.status === 404) return undefined;
+    if (!res.ok) {
+      throw new Error(`Zerion request failed with status ${res.status}`);
+    }
+
+    const data = await res.json();
+    if (!data || typeof data !== "object") {
+      throw new Error("Zerion response has invalid data");
+    }
+
+    const entry = data as ZerionEntry;
+    if (
+      typeof entry.wallet !== "string" ||
+      entry.wallet.toLowerCase() !== normalizedAddress
+    ) {
+      throw new Error("Zerion response returned a different wallet");
+    }
+
+    return entry;
+  },
+  data: (entry: ZerionEntry | undefined) => ({
+    XP: {
+      Total: getNumber(entry, "earnedXP"),
+      Level: getNumber(entry, "level"),
+      Rank: getNumber(entry, "position"),
+    },
+  }),
+  total: (entry: ZerionEntry | undefined) => ({
+    XP: getNumber(entry, "earnedXP"),
+  }),
+  rank: (entry: ZerionEntry | undefined) => getNumber(entry, "position"),
+  supportedAddressTypes: ["evm"],
+} satisfies AdapterExport<ZerionEntry | undefined>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Zerion leaderboard integration for supported EVM wallet addresses.
  - Displays wallet XP, level, and ranking metrics.
  - Handles unavailable profiles and invalid leaderboard responses gracefully, showing zero values where data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->